### PR TITLE
Center board headings over grids

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -16,11 +16,17 @@ body {
     gap: 1rem;
 }
 
+.board-column {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
 .fleet-status {
     list-style: none;
     padding: 0;
     text-align: left;
-    min-width: 8 rem;
+    min-width: 8rem;
 }
 
 .board {

--- a/src/template.html
+++ b/src/template.html
@@ -13,16 +13,20 @@
 
     <main class="boards">
         <section id="board1">
-            <h2>Your Waters</h2>
             <div class="board-area">
+                <div class="board-column">
+                    <h2>Your Waters</h2>
+                    <div class="board"></div>
+                </div>
                 <ul class="fleet-status"></ul>
-                <div class="board"></div>
             </div>
         </section>
         <section id="board2">
-            <h2>Enemy Waters</h2>
             <div class="board-area">
-                <div class="board"></div>
+                <div class="board-column">
+                    <h2>Enemy Waters</h2>
+                    <div class="board"></div>
+                </div>
                 <ul class="fleet-status"></ul>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- Align "Your Waters" and "Enemy Waters" headers directly above their boards by wrapping each grid and heading in a flex column container
- Add CSS to center the headings and ensure fleet list retains fixed width

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8997757548320866806571bb11411